### PR TITLE
INT-7213 - Change deprecated Events API to Events 2 API for Moodle 3.2 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/comms"]
 	path = include/comms
-	url = git@github.com:gerkekok/ephorus-comms.git
+url=https://github.com/Ephorus/ephorus-comms.git

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,88 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+if (!defined('MOODLE_INTERNAL')) {
+    die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
+}
+require_once($CFG->dirroot.'/plagiarism/ephorus/lib.php');
+class plagiarism_ephorus_observer {
+	/**
+	 * Handle the assignment assessable_uploaded event for files.
+	 * @param \assignsubmission_file\event\assessable_uploaded $event
+	 */
+	public static function assignsubmission_file_uploaded(
+	    \assignsubmission_file\event\assessable_uploaded $event) {
+	    $eventdata = $event->get_data();
+	    $eventdata['eventtype'] = 'file_uploaded';
+	    $eventdata['other']['modulename'] = 'assign';
+	    $plugin = new plagiarism_plugin_ephorus();
+	    $plugin->event_handler($eventdata);
+	}
+    /**
+     * Handle the assignment assessable_uploaded event for online text.
+     * @param \assignsubmission_onlinetext\event\assessable_uploaded $event
+     */
+    public static function assignsubmission_onlinetext_uploaded(
+        \assignsubmission_onlinetext\event\assessable_uploaded $event) {
+        $eventdata = $event->get_data();
+        $eventdata['eventtype'] = 'content_uploaded';
+        $eventdata['other']['modulename'] = 'assign';
+        $plugin = new plagiarism_plugin_ephorus();
+        $plugin->event_handler($eventdata);
+    }
+    /**
+     * Handle the assignment assessable_submitted event.
+     * @param \mod_assign\event\assessable_submitted $event
+     */
+    public static function assignsubmission_submitted(
+        \mod_assign\event\assessable_submitted $event) {
+        $eventdata = $event->get_data();
+        $eventdata['eventtype'] = 'assessable_submitted';
+        $eventdata['other']['modulename'] = 'assign';
+        $plugin = new plagiarism_plugin_ephorus();
+        $plugin->event_handler($eventdata);
+    }
+	/**
+	 * Handle the course_module_created event.
+	 * @param \core\event\course_module_created $event
+	 */
+	public static function course_module_created(
+        \core\event\course_module_created $event) {
+		$eventdata = $event->get_data();
+        $eventdata['eventtype'] = 'mod_created';
+        $plugin = new plagiarism_plugin_ephorus();
+        $plugin->event_handler($eventdata);
+	}
+	/**
+	 * Handle the course_module_updated event.
+	 * @param \core\event\course_module_updated $event
+	 */
+	public static function course_module_updated(
+        \core\event\course_module_updated $event) {
+		$eventdata = $event->get_data();
+        $eventdata['eventtype'] = 'mod_updated';
+        $plugin = new plagiarism_plugin_ephorus();
+        $plugin->event_handler($eventdata);
+	}
+	/**
+	 * Handle the course_module_deleted event.
+	 * @param \core\event\course_module_deleted $event
+	 */
+	public static function course_module_deleted(
+        \core\event\course_module_deleted $event) {
+		global $DB;
+        $DB->delete_records('plagiarism_eph_assignment', array('id' => $ephorus_assignment));
+	}
+}

--- a/db/events.php
+++ b/db/events.php
@@ -15,32 +15,31 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /*
-* Event Handlers
+* Observers
 */
-$handlers = array (
-    'assessable_file_uploaded' => array (
-        'handlerfile'      => '/plagiarism/ephorus/lib.php',
-        'handlerfunction'  => 'plagiarism_ephorus_event_file_uploaded',
-        'schedule'         => 'instant'
+$observers = array (
+    array(
+        'eventname' => '\assignsubmission_file\event\assessable_uploaded',
+        'callback'  => 'plagiarism_ephorus_observer::assignsubmission_file_uploaded'
     ),
-    'assessable_files_done' => array (
-        'handlerfile'      => '/plagiarism/ephorus/lib.php',
-        'handlerfunction'  => 'plagiarism_ephorus_event_files_done',
-        'schedule'         => 'instant'
+    array(
+        'eventname' => '\assignsubmission_onlinetext\event\assessable_uploaded',
+        'callback'  => 'plagiarism_ephorus_observer::assignsubmission_onlinetext_uploaded'
     ),
-    'mod_created' => array (
-        'handlerfile'      => '/plagiarism/ephorus/lib.php',
-        'handlerfunction'  => 'plagiarism_ephorus_event_mod_created',
-        'schedule'         => 'instant'
+    array(
+        'eventname' => '\mod_assign\event\assessable_submitted',
+        'callback'  => 'plagiarism_ephorus_observer::assignsubmission_submitted'
     ),
-    'mod_updated' => array (
-        'handlerfile'      => '/plagiarism/ephorus/lib.php',
-        'handlerfunction'  => 'plagiarism_ephorus_event_mod_updated',
-        'schedule'         => 'instant'
+    array(
+        'eventname' => '\core\event\course_module_created',
+        'callback'  => 'plagiarism_ephorus_observer::course_module_created'
     ),
-    'mod_deleted' => array (
-        'handlerfile'      => '/plagiarism/ephorus/lib.php',
-        'handlerfunction'  => 'plagiarism_ephorus_event_mod_deleted',
-        'schedule'         => 'instant'
+    array(
+        'eventname' => '\core\event\course_module_updated',
+        'callback'  => 'plagiarism_ephorus_observer::course_module_updated'
     ),
+    array(
+        'eventname' => '\core\event\course_module_deleted',
+        'callback'  => 'plagiarism_ephorus_observer::course_module_deleted'
+    )
 );

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2015120700;
+$plugin->version   = 2016102101;
 $plugin->requires  = 2013101800;
 $plugin->cron      = 0;
 $plugin->component = 'plagiarism_ephorus';


### PR DESCRIPTION
The Events API has been deprecated and will be removed in Moodle 3.2, so the current Events API implementation requires changing to the Events 2 API in order to support Moodle 3.2.